### PR TITLE
feat: adds HasSlug trait and implements on the post model

### DIFF
--- a/app/Concerns/HasSlug.php
+++ b/app/Concerns/HasSlug.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+trait HasSlug
+{
+    protected static function bootHasSlug(): void
+    {
+        static::creating(function (Model $model) {
+            if (empty($model->slug)) {
+                $slug = Str::slug($model->title);
+                $originalSlug = $slug;
+                $count = 2;
+                while (static::whereSlug($slug)->exists()) {
+                    $slug = $originalSlug.'-'.$count++;
+                }
+                $model->slug = $slug;
+            }
+        });
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Concerns\HasSlug;
 use Database\Factories\PostFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -16,7 +17,7 @@ use Illuminate\Support\Str;
 class Post extends Model
 {
     /** @use HasFactory<PostFactory> */
-    use HasFactory, SoftDeletes;
+    use HasFactory, HasSlug, SoftDeletes;
 
     protected $fillable = [
         'user_id',
@@ -28,21 +29,23 @@ class Post extends Model
     {
         parent::boot();
 
-        self::creating(function ($model) {
-            $slug = Str::slug($model->title);
-            $originalSlug = $slug;
-            $count = 2;
-            while (static::whereSlug($slug)->exists()) {
-                $slug = $originalSlug.'-'.$count++;
-            }
-            $model->slug = $slug;
-        });
+        // mmoved to the HasSlug Trait
+//        self::creating(function ($model) {
+//            $slug = Str::slug($model->title);
+//            $originalSlug = $slug;
+//            $count = 2;
+//            while (static::whereSlug($slug)->exists()) {
+//                $slug = $originalSlug.'-'.$count++;
+//            }
+//            $model->slug = $slug;
+//        });
     }
 
-    public function getRouteKeyName(): string
-    {
-        return 'slug';
-    }
+    // This one has moved to the HasSlug trait as well
+//    public function getRouteKeyName(): string
+//    {
+//        return 'slug';
+//    }
 
     public function translations(): HasMany
     {


### PR DESCRIPTION
Adds HasSlug trait to be used on multiple models, includes getRouteKeyName() by slug. Implemented on the Post model for a starter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Posts now use human-readable URLs based on their titles (slugs) for navigation and sharing.
  - Slugs are automatically generated when creating a post and ensured to be unique (numeric suffix added if needed).
  - Routing resolves posts by slug instead of an internal ID, improving readability and SEO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->